### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 A secure MCP (Model Context Protocol) server that enables AI agents to interact with the Authenticator App. It provides seamless access to 2FA codes and passwords, allowing AI agents to assist with automated login processes while maintaining security. This tool bridges the gap between AI assistants and secure authentication, making it easier to manage your credentials across different platforms and websites.
 
+<a href="https://glama.ai/mcp/servers/@firstorderai/authenticator_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@firstorderai/authenticator_mcp/badge" alt="Authenticator App Server MCP server" />
+</a>
+
 ## How it works
 
 1. Open your AI agent's integrated chat interface (such as Cursor's agent mode).


### PR DESCRIPTION
This PR adds a badge for the [Authenticator App MCP Server](https://glama.ai/mcp/servers/@firstorderai/authenticator_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@firstorderai/authenticator_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@firstorderai/authenticator_mcp/badge" alt="Authenticator App Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.